### PR TITLE
fixes in dd_AddNotify and DiskInsertSequence

### DIFF
--- a/dd_funcs.c
+++ b/dd_funcs.c
@@ -1734,7 +1734,11 @@ static LONG dd_AddNotify (struct DosPacket *pkt, globaldata *g)
 			no->unparsed++;     /* make it a cstring!! */
 		}
 		else
+		{
+			FreeMemP (no->objectname, g);
+			FreeMemP (no, g);
 			return DOSFALSE;
+		}
 	}
 	else
 	{
@@ -1750,6 +1754,8 @@ static LONG dd_AddNotify (struct DosPacket *pkt, globaldata *g)
 	if (IsDelDir (oi))
 	{
 		pkt->dp_Res2 = ERROR_OBJECT_WRONG_TYPE;
+		FreeMemP (no->objectname, g);
+		FreeMemP (no, g);
 		return DOSFALSE;
 	}
 #endif

--- a/dd_funcs.c
+++ b/dd_funcs.c
@@ -1744,7 +1744,7 @@ static LONG dd_AddNotify (struct DosPacket *pkt, globaldata *g)
 	{
 		/* try to locate object */
 		found = FindObject (&oi, no->objectname+1, &filefi, (ULONG *)&pkt->dp_Res2, g);
-		if (found)
+		if (found && (IsVolume(filefi) || (ULONG)filefi.file.direntry > 2))
 		{
 			no->anodenr = IsVolume(filefi) ? ANODE_ROOTDIR : filefi.file.direntry->anode;
 		}

--- a/volume.c
+++ b/volume.c
@@ -509,9 +509,11 @@ void DiskInsertSequence(struct rootblock *rootblock, globaldata *g)
 				if (ddblk->blk.id == DELDIRID)
 				{
 					for (i=0; i<31; i++)
+					{
 						nr = ddblk->blk.entries[i].anodenr;
 						if (nr)
 							FreeAnodesInChain(nr, g);
+					}
 				}
 			}
 			FreeLRU ((struct cachedblock *)ddblk);


### PR DESCRIPTION
Fixes to couple of issues:
- DiskInsertSequence code upgrading old-style DELDIR would leak anodes due to missing curly braces
- dd_AddNotify would leak memory in couple of the error code paths
- dd_AddNotify does a read hit to address 2, 3 or 4 if applied to some special objects. This could be reproduced by attempting to AddNotify the deldir.