### PR TITLE
fix(volume): NULL pointer read in SetPartitionLimits during handler startup

### DIFF
--- a/volume.c
+++ b/volume.c
@@ -1193,6 +1193,12 @@ end_error:
 
 static void SetPartitionLimits(globaldata *g)
 {
+	/* g->geom is not allocated yet when called from the early
+	 * CalculateBlockSize() in Initialize(); the limits are recomputed
+	 * via GetDriveGeometry() once the geometry is known.
+	 */
+	if (!g->geom)
+		return;
 	g->firstblocknative = g->dosenvec->de_LowCyl * g->geom->dg_CylSectors;
 	g->lastblocknative = (g->dosenvec->de_HighCyl + 1) * g->geom->dg_CylSectors;
 	// align to block size if partition was not already block size aligned


### PR DESCRIPTION
`Initialize()` calls `CalculateBlockSize()` before `g->geom` is allocated, and its tail call to `SetPartitionLimits()` reads `g->geom->dg_CylSectors` through the `NULL` pointer.

Harmless in practice (the limits are recalculated by `GetDriveGeometry()` once the geometry is read) but it trips MuForce with a 
```
LONG READ from 0000000C                        PC: 00E41308
USP : 40498BD8 SR: 0000  (U0)(-)(-)  TCB: 40497C48
Data: 0000000C 00000004 00001000 4FDFD10C 4FDFD0E0 00000000 00000000 00000000
Addr: 00000000 4FDFD11C 4046C480 4FDFD11C 4041A410 4FDFD10C 4000097C 403CD138
Stck: 00001000 4FDFD10C 4046C480 40418E54 4000097C 00E41442 00004000 4046C480
Stck: 00E3F69E 40497C48 4FDFD10C 00000000 4FDFD0E0 4046C480 4041A410 40497CA4
Name: "DH0"  Hunk 0000 Offset 000026B4
```
in the handler task on every mount. **Skip the calculation until the geometry exists.**