### PR TITLE
fix(startup): report pfs3aio, not the next ROM module, in C:Version

### DIFF
--- a/fsresource.c
+++ b/fsresource.c
@@ -70,13 +70,13 @@ void AddToFSResource(ULONG dostype, BPTR seglist, struct ExecBase *SysBase)
 	}
 }
 
-extern void entrypoint(void);
+extern const ULONG PFS3FakeSeg[];
 // PFS\1 PDS\1 PFS\3 PDS\3
 static const ULONG fsids[] = { 0x50465301, 0x50445301, 0x50465303, 0x50445303, 0 };
 void ResidentAddToFSResource(void)
 {
 	struct ExecBase *eb =  *((struct ExecBase **)4);
 	for (int i = 0; fsids[i]; i++) {
-		AddToFSResource(fsids[i], MKBADDR(entrypoint) - 2, eb);
+		AddToFSResource(fsids[i], MKBADDR(PFS3FakeSeg), eb);
 	}
 }

--- a/startup.s
+++ b/startup.s
@@ -9,6 +9,17 @@
 	.globl _version
 
 	bra.s _entrypoint
+	dc.w 0			/* pad: the fake segment needs longword alignment */
+
+	/* Fake segment published in FileSystem.resource (fse_SegList =
+	 * MKBADDR(_PFS3FakeSeg)). It must precede _PFS3Resident: C:Version
+	 * identifies a handler by scanning its seglist forward for the
+	 * romtag. CreateProc enters a seglist at BADDR+4, hence the bra
+	 * to the real entrypoint. */
+	.globl _PFS3FakeSeg
+_PFS3FakeSeg:
+	dc.l 0			/* next segment: end of list */
+	bra.w _entrypoint	/* seglist entry point (BADDR+4) */
 
 _PFS3Resident:
 	dc.w 0x4afc
@@ -18,10 +29,6 @@ _PFS3Resident:
 	dc.l _shortname
 	dc.l _version+6
 	dc.l _ResidentAddToFSResource
-
-	/* fake segment */
-	dc.l 0
-	dc.l 16
 
 _entrypoint:
 


### PR DESCRIPTION
`C:Version` identifies a filesystem by scanning the handler's seglist for an embedded Resident tag. The fake segment registered in `FileSystem.resource` pointed behind the romtag, so the scan missed it and ran on until the next ROM module's tag, showing e.g. "`SmartFilesystem`" for a PFS3 mount (in my setup).
```
Version DH0:
SmartFilesystem 1.280
```
Place the fake segment before the romtag and register it by name so the scan finds pfs3aio itself.
```
Version DH0: 
pfs3aio 20.0
```